### PR TITLE
Updated `parallel` parsing

### DIFF
--- a/example/mm_jobman.sh
+++ b/example/mm_jobman.sh
@@ -346,8 +346,8 @@ EOF
         # Execute or echo the full command
         if [ "$dryrun" = true ]; then
             echo -e "${full_cmd}"  # Replace '&&' with new lines for dry run
-        # else
-        #     eval "$full_cmd"
+        else
+            eval "$full_cmd"
         fi
  
     done 

--- a/example/mm_jobman.sh
+++ b/example/mm_jobman.sh
@@ -20,7 +20,7 @@ show_help() {
     echo "  --parallel-commands          Sets how many commands to run in parallel (default: 1)" 
     echo "  --imageVolSize               Define image volume size in GB (default depends on image size). "
     echo "  --dryrun                     If applied, will print all commands instead of running any."
-    echo "  --cwd '<value>'              Specified working directory (default: /home/ec2-user)"
+    echo "  --cwd '<value>'              Specified working directory (default: ~)"
     echo "  --help                       Show this help message"
 }
 


### PR DESCRIPTION
* Default of `parallel` is set to `c_value`
* Commands running by themselves (either `parallel` set to 1 or is a remainder) has no `parallel` prefix
* No longer prints out entire job script