### PR TITLE
Added Upload trailing slash check + Download fix

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -23,7 +23,7 @@ username=aw3600
  --env ENV_NAME=pecotmr \
  --imageVolSize 10 \
  --opcenter 54.81.85.209 \
- --download "statfungen/ftp_fgc_xqtl/ROSMAP/genotype/geno_by_chrom/:/home/$username/input" \
+ --download "statfungen/ftp_fgc_xqtl/ROSMAP/genotype/geno_by_chrom/:/home/$username/input/" \
  --download-include 'ROSMAP_NIA_WGS.leftnorm.bcftools_qc.plink_qc.1.*'  \
  --recursive true \
  --upload /home/$username/output:statfungen/ftp_fgc_xqtl/ \

--- a/src/mm_jobman.sh
+++ b/src/mm_jobman.sh
@@ -259,8 +259,8 @@ create_download_commands() {
   # if [ ${#downloadOpt[@]} -eq 0 ]; then
     for i in "${!download_local[@]}"; do
       # If local folder has a trailing slash, we are copying into a folder, therefore we make the folder
-      if [[ ${download_remote[$i]} =~ /$ ]]; then
-        download_cmd+="mkdir -p ${download_local[$i]}\n"
+      if [[ ${download_local[$i]} =~ /$ ]]; then
+        download_cmd+="mkdir -p ${download_local[$i]%\/}\n"
       fi
       download_cmd+="aws s3 cp s3://${download_remote[$i]} ${download_local[$i]}"
 
@@ -320,7 +320,7 @@ create_upload_commands() {
   # If no uploadOpt option, just create upload commands
   if [ ${#uploadOpt[@]} -eq 0 ]; then
     for i in "${!upload_local[@]}"; do
-        upload_cmd+="mkdir -p ${upload_local[$i]}\n"
+        upload_cmd+="mkdir -p ${upload_local[$i]%\/}\n"
         local upload_folder=${upload_remote[$i]%\/}
         if [[ ${upload_local[$i]} =~ /$ ]]; then
           upload_cmd+="aws s3 sync ${upload_local[$i]} s3://${upload_folder}\n"

--- a/src/mm_jobman.sh
+++ b/src/mm_jobman.sh
@@ -321,11 +321,12 @@ create_upload_commands() {
   if [ ${#uploadOpt[@]} -eq 0 ]; then
     for i in "${!upload_local[@]}"; do
         upload_cmd+="mkdir -p ${upload_local[$i]}\n"
+        local upload_folder=${upload_remote[$i]%\/}
         if [[ ${upload_local[$i]} =~ /$ ]]; then
-          upload_cmd+="aws s3 sync ${upload_local[$i]} s3://${upload_remote[$i]}\n"
+          upload_cmd+="aws s3 sync ${upload_local[$i]} s3://${upload_folder}\n"
         else  
           local last_folder=$(basename "${upload_local[$i]}")
-          upload_cmd+="aws s3 sync ${upload_local[$i]} s3://${upload_remote[$i]}/$last_folder\n"
+          upload_cmd+="aws s3 sync ${upload_local[$i]} s3://${upload_folder}/$last_folder\n"
         fi
     done
   fi


### PR DESCRIPTION
* Remove trailing slash on upload remote if given
* Removed trailing slashes in mkdir commands
* Fixed typo on download local trailing slash check
    * If the download local folder has a trailing slash, we are copying files *into* a folder, not overriding a file into the remote instance
    * Updated README command