### PR TITLE
Fixed typo on script to not have OOM protection

### DIFF
--- a/src/mm_interactive.sh
+++ b/src/mm_interactive.sh
@@ -133,7 +133,7 @@ float_submit="float submit -a $OP_IP \
 --imageVolSize $image_vol_size \
 --rootVolSize $root_vol_size \
 --gateway $gateway \
---migratePolicy [disable=true, evadeOOM=true] \
+--migratePolicy [disable=true, evadeOOM=false] \
 --publish $publish \
 --securityGroup $securityGroup \
 $dataVolumeOption \

--- a/src/mm_interactive.sh
+++ b/src/mm_interactive.sh
@@ -4,7 +4,7 @@
 default_OP_IP="44.222.241.133"
 default_s3_path="s3://statfungen/ftp_fgc_xqtl/"
 default_VM_path="/data/"
-default_image="docker.io/rfeng2023/pixi-jovyan:latest"
+default_image="docker.io/peterz27/sos-jupyter"
 default_core=4
 default_mem=16
 default_publish="8888:8888"

--- a/src/mm_interactive.sh
+++ b/src/mm_interactive.sh
@@ -13,7 +13,7 @@ default_gateway="g-9xahbrb5rkbs0ic8yzylk"
 default_include_dataVolume="yes"
 default_vm_policy="onDemand"
 default_image_vol_size=60
-default_root_vol_size=40
+default_root_vol_size=70
 default_ide="tmate"
 
 # Initialize variables to empty for user and password


### PR DESCRIPTION
In addition to a larger swap file size on the opcenter (4GB -> 16GB), we will be turning off OOM protection and migration as a short term solution.

Additionally, the default image is set to sos-jupyter. The script should not affect the current work-in-progres package installation, as that is specific to the pixi-jovyan image.

@gaow , Charlie and I will bring it up - but interactive jobs should be using the latest script