### PR TITLE
Updated interactive script

### DIFF
--- a/src/mm_interactive.sh
+++ b/src/mm_interactive.sh
@@ -18,8 +18,7 @@ declare -A defaults=(
     [image_vol_size]=60
     [root_vol_size]=70
     [ide]="tmate"
-    [host_init]=""
-    [mount_init]=""
+    [package_installation]="false"
 )
 
 # Initialize variables
@@ -55,8 +54,7 @@ usage() {
     echo "  -am, --additional_mounts <mount> Add additional mounts"
     echo "  --no-mount                       Disable all mounting"
     echo "  -jn, --job_name <name>           Set the job name"
-    echo "  --host-init <script>             Set the host initialization script"
-    echo "  --mount-init <script>            Set the mount initialization script"
+    echo "  --package-installation           Set to package installation setup"
     echo "  -h, --help                       Display this help message"
 }
 
@@ -80,8 +78,7 @@ while [[ "$#" -gt 0 ]]; do
         -am|--additional_mounts) additional_mounts+=("$2"); shift ;;
         --no-mount) no_mount=true ;;
         -jn|--job_name) job_name="$2"; shift ;;
-        --host-init) params[host_init]="$2"; shift ;;
-        --mount-init) params[mount_init]="$2"; shift ;;
+        --package-installation) params[package_installation]="true"; ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown parameter passed: $1"; usage; exit 1 ;;
     esac
@@ -111,13 +108,14 @@ fi
 # Data volume handling
 if [[ $no_mount == false ]]; then
     dataVolumeOption=("--dataVolume" "[mode=rw,endpoint=s3.us-east-1.amazonaws.com]${params[s3_path]}:${params[VM_path]}")
-    for mount in "${additional_mounts[@]}"; do
-        dataVolumeOption+=("--dataVolume" "[mode=rw,endpoint=s3.us-east-1.amazonaws.com]${mount}")
-    done
+    if [[ ${#additional_mounts[@]} -gt 0 ]]; then  # Check if additional_mounts has any elements
+        for mount in "${additional_mounts[@]}"; do
+            dataVolumeOption+=("--dataVolume" "[mode=rw,endpoint=s3.us-east-1.amazonaws.com]${mount}")
+        done
+    fi
 else
     dataVolumeOption=()
 fi
-
 # Determine VM Policy
 case "$(echo "${params[vm_policy]}" | tr '[:upper:]' '[:lower:]')" in
     spotonly) vm_policy_command="[spotOnly=true]" ;;
@@ -130,17 +128,17 @@ case "$(echo "${params[vm_policy]}" | tr '[:upper:]' '[:lower:]')" in
 esac
 
 # Check if specified scripts exist
-check_script() {
-    local script_path="$1"
-    local script_type="$2"
-    if [[ -n "$script_path" && ! -f "$script_path" ]]; then
-        echo "Error: $script_type script '$script_path' does not exist."
-        exit 1
-    fi
+function find_script_dir() {
+    SOURCE=${BASH_SOURCE[0]}
+    while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+        DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+        SOURCE=$(readlink "$SOURCE")
+        [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+    done
+    DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+    echo $DIR
 }
-
-check_script "${params[host_init]}" "Host initialization"
-check_script "${params[mount_init]}" "Mount initialization"
+script_dir=$(find_script_dir)
 
 # Log in
 echo "Logging in to ${params[OP_IP]}"
@@ -167,10 +165,10 @@ float_submit_args=(
 )
 
 # Add host-init and mount-init if specified
-[[ -n "${params[host_init]}" ]] && float_submit_args+=("--hostInit" "${params[host_init]}")
-if [[ -n "${params[mount_init]}" ]]; then
+if [[ "${params[package_installation]}" == "true" ]]; then
     float_submit_args+=(
-        "-j" "${params[mount_init]}"
+        "-j" "$script_dir/bind_mount.sh"
+        "--hostInit" "$script_dir/host_init.sh"
         "--dirMap" "/mnt/jfs:/mnt/jfs"
         "--dataVolume" "[size=100]:/mnt/jfs_cache"
     )
@@ -184,7 +182,7 @@ echo -e "[Float submit command]: ${float_submit_args[*]}"
 
 # Submit the job and retrieve job ID
 float_submit_output=$(echo "yes" | "${float_submit_args[@]}")
-jobid=$(echo "$float_submit_output" | grep 'id:' | awk -F'id: ' '{print $2}' | awk '{print $1}')
+jobid=$(echo "$float_submit_output" | grep 'id:' | awk -F'id: ' '{print $2}' | awk '{print $1}' || true)
 if [[ -z "$jobid" ]]; then
     echo "Error returned from float submission command! Exiting..."
     exit 1
@@ -197,7 +195,7 @@ get_public_ip() {
     echo "[$(date)]: Waiting to retrieve the public IP (~1min)..."
     local IP_ADDRESS=""
     while [[ -z "$IP_ADDRESS" ]]; do
-        IP_ADDRESS=$(float show -j "$jobid" | grep -A 1 portMappings | tail -n 1 | awk '{print $4}')
+        IP_ADDRESS=$(float show -j "$jobid" | grep -A 1 portMappings | tail -n 1 | awk '{print $4}' || true)
         if [[ -n "$IP_ADDRESS" ]]; then
             echo "PUBLIC IP: $IP_ADDRESS"
         else
@@ -212,13 +210,13 @@ get_tmate_session() {
     local jobid="$1"
     echo "[$(date)]: Waiting for the job to execute and retrieve tmate web session (~5min)..."
     while true; do
-        url=$(float log -j "$jobid" cat stdout.autosave | grep "web session:" | head -n 1)
+        url=$(float log -j "$jobid" cat stdout.autosave | grep "web session:" | head -n 1 || true)  
         if [[ -n "$url" ]]; then
             local tmate_session=$(echo "$url" | awk '{print $3}')
             echo "To access the server, copy this URL in a browser: $tmate_session"
             echo "To access the server, copy this URL in a browser: $tmate_session" > "${jobid}_tmate_session.log"
 
-            local ssh=$(float log -j "$jobid" cat stdout.autosave | grep "ssh session:" | head -n 1)
+            local ssh=$(float log -j "$jobid" cat stdout.autosave | grep "ssh session:" | head -n 1 || true)
             local ssh_tmate=$(echo "$ssh" | awk '{print $3,$4}')
             echo "SSH session: $ssh_tmate"
             echo "SSH session: $ssh_tmate" >> "${jobid}_tmate_session.log"
@@ -235,8 +233,8 @@ get_jupyter_token() {
     local ip_address="$2"
     echo "[$(date)]: Waiting for the job to execute and retrieve Jupyter token (~10min)..."
     while true; do
-        url=$(float log -j "$jobid" cat stderr.autosave | grep token= | head -n 1)
-        no_jupyter=$(float log -j "$jobid" cat stdout.autosave | grep "JupyterLab is not available." | head -n 1)
+        url=$(float log -j "$jobid" cat stderr.autosave | grep token= | head -n 1 || true)
+        no_jupyter=$(float log -j "$jobid" cat stdout.autosave | grep "JupyterLab is not available." | head -n 1 || true)
 
         if [[ $url == *token=* ]]; then
             local token=$(echo "$url" | sed -E 's|.*http://[^/]+/(lab\?token=[a-zA-Z0-9]+).*|\1|')


### PR DESCRIPTION
* I brought back the `hostinit `and `bind_mount `script to always be a part of the float submit command when `--package-installation` is set to true (which i also brought back)
* Brought back `find_script_dir`, as we expect the user to have the `mmcloud_columbia `github repo, which will also have our `hostinit `and `bind_mount `script
* `set -u` will make Bash treat the usage of an undefined variable as an error, so I updated the case where `additional_mounts `is empty
* with `set -e`, even when a grep does not find a match (like when finding the tmate session), that will stop the script. So I added a  `|| true` safeguard to snippets that use grep