### PR TITLE
Updated base_api_url to allow for suspension on private subnets

### DIFF
--- a/src/host_init_interactive.sh
+++ b/src/host_init_interactive.sh
@@ -417,7 +417,8 @@ def main_process():
         sys.exit(1)
 
     # Construct the API URLs
-    base_api_url = f"{public_ip}:8888"
+    # base_api_url = f"{public_ip}:8888"
+    base_api_url = "http://127.0.0.1:8888"
     kernels_api_url = f"{base_api_url}/api/kernels"
     sessions_api_url = f"{base_api_url}/api/sessions"
     data['api_url'] = base_api_url

--- a/src/mm_interactive.sh
+++ b/src/mm_interactive.sh
@@ -227,7 +227,6 @@ float_submit_args=(
     "--env" "VMUI=$ide"
     "${dataVolumeOption[@]}"
     "--env" "ALLOWABLE_IDLE_TIME_SECONDS=$idle_time"
-    "--subnet" "subnet-0527eb4604ecdfdde"
 )
 
 # If image vol size and root vol size not empty, populate float args

--- a/src/mm_interactive.sh
+++ b/src/mm_interactive.sh
@@ -227,6 +227,7 @@ float_submit_args=(
     "--env" "VMUI=$ide"
     "${dataVolumeOption[@]}"
     "--env" "ALLOWABLE_IDLE_TIME_SECONDS=$idle_time"
+    "--subnet" "subnet-0527eb4604ecdfdde"
 )
 
 # If image vol size and root vol size not empty, populate float args


### PR DESCRIPTION
When submitting a job, it is random what subnet the job is submitted to, unless explicitly stated. The jupyter ssupension script will not properly suspend the instance if the instance is in a private subnet. The way that the script works is that it uses API calls on the jupyter host to find if it is active. This is somehow blocked when the instance is in a private subnet, thus the need to explicitly make interactivite jobs run in a public subnet

This should pose minimal security risk, because for jupyter instance, a token is needed to login anyway. 