### PR TITLE
Updated path and preparation stage time

### DIFF
--- a/src/bind_mount.sh
+++ b/src/bind_mount.sh
@@ -44,8 +44,7 @@ link_paths() {
         # Set a basic .bashrc and .profile if efs does not have them
         if [ ! -f ${efs_path}/.bashrc ]; then
             tee ${efs_path}/.bashrc << EOF
-export PATH="/mnt/efs/shared/.pixi/bin:\${PATH}"
-export PATH="\${HOME}/.pixi/bin:\${PATH}"
+export PATH="\${HOME}/.pixi/bin:/mnt/efs/shared/.pixi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 unset PYTHONPATH
 export PYDEVD_DISABLE_FILE_VALIDATION=1
 EOF

--- a/src/host_init_interactive.sh
+++ b/src/host_init_interactive.sh
@@ -173,7 +173,7 @@ sleep_time_between_suspend_attempts = int(os.getenv('SLEEP_TIME_BETWEEN_SUSPEND_
 idle_check_interval_seconds = int(os.getenv('IDLE_CHECK_INTERVAL_SECONDS', '60'))
 max_jupyter_pid_attempts = int(os.getenv('MAX_JUPYTER_PID_ATTEMPTS', '20'))
 jupyter_pid_retry_interval_seconds = int(os.getenv('JUPYTER_PID_RETRY_INTERVAL_SECONDS', '60'))
-max_preparation_stage_time_seconds = int(os.getenv('MAX_PREPARATION_STAGE_TIME_SECONDS', '1800'))   # Default 30 min
+max_preparation_stage_time_seconds = int(os.getenv('MAX_PREPARATION_STAGE_TIME_SECONDS', '7200'))   # Default 2 hours
 max_log_file_size_bytes = int(os.getenv('MAX_LOG_FILE_SIZE_BYTES', '10240000'))
 max_log_files = int(os.getenv('MAX_LOG_FILES', '10'))
 


### PR DESCRIPTION
- Decided to explicitly set the PATH so that it does not keep being pre-prended to with every suspend/resume, and to make sure `{HOME}/.pixi/bin` is first
- Updated the preparation time in the jupyter suspension script to 2 hours. This is so if the user is not using a newly-made instance at all, or doing small commands in the terminal, it will still take 2 hours to suspend unless activity is found, then the timer will resent and still count down from two hours.