### PR TITLE
Added default mount to statfungen/ftp_fgc_xqtl under /data in wrapper…

### DIFF
--- a/src/mm_batch.sh
+++ b/src/mm_batch.sh
@@ -5,6 +5,8 @@ opcenter=3.82.198.55
 gateway=g-sidlpgb7oi9p48kxycpmn
 efs_ip=10.1.10.210
 security_group=sg-02867677e76635b25
+initial_mount="statfungen/ftp_fgc_xqtl/:/data"
+initial_mountOpt="mode=r"
 ################################################################
 
 # Find parent directory of mm_jobman.sh
@@ -20,4 +22,4 @@ find_script_dir() {
 }
 
 script_dir=$(find_script_dir)
-$script_dir/mm_jobman.sh -o $opcenter -g $gateway -efs $efs_ip -sg $security_group $@
+$script_dir/mm_jobman.sh -o $opcenter -g $gateway -efs $efs_ip -sg $security_group --mount $initial_mount --mountOpt $initial_mountOpt $@

--- a/src/mm_interactive.sh
+++ b/src/mm_interactive.sh
@@ -5,6 +5,8 @@ opcenter=44.222.241.133
 gateway=g-sidlpgb7oi9p48kxycpmn
 efs_ip=10.1.10.210
 security_group=sg-02867677e76635b25
+initial_mount="statfungen/ftp_fgc_xqtl/:/data"
+initial_mountOpt="mode=r"
 ######################################################################
 
 # Find parent directory of mm_jobman.sh
@@ -20,4 +22,4 @@ find_script_dir() {
 }
 
 script_dir=$(find_script_dir)
-$script_dir/mm_jobman.sh -o $opcenter -g $gateway -efs $efs_ip -sg $security_group $@
+$script_dir/mm_jobman.sh -o $opcenter -g $gateway -efs $efs_ip -sg $security_group --mount $initial_mount --mountOpt $initial_mountOpt $@


### PR DESCRIPTION
… scripts

Example:
```bash
[ashleyt@ashleyt2 gaowang_base_image]$ ~/mmcloud_columbia/src/mm_batch.sh --oem-packages --job-script test_script.sh --job-size 2 --dryrun --mount second_bucket/test:/test_dir --mountOpt mode=rw
Starting batch mode...

Enter user for 3.82.198.55: ashley_oem
Enter password for 3.82.198.55:
Login Succeeded!
#-------------
float submit -a 3.82.198.55
        --securityGroup sg-02867677e76635b25
        -i 'quay.io/danielnachun/tmate-minimal'
        -j test_script_0.mmjob.sh
        -c 2
        -m 16
        --hostInit /memverge/home/ashleyt/mmcloud_columbia/src/host_init.sh
        --dirMap /mnt/efs:/mnt/efs
        --withRoot
        --vmPolicy [spotOnly=true]
        --env EFS=10.1.10.210
 --dataVolume '[mode=r,endpoint=s3.us-east-1.amazonaws.com]s3://statfungen/ftp_fgc_xqtl/:/data' --dataVolume '[mode=rw,endpoint=s3.us-east-1.amazonaws.com]s3://second_bucket/test:/test_dir' --imageVolSize 3 --env MODE=oem_packages
```